### PR TITLE
Avoid redundant "sa-" portion in the SA names...

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,8 @@ terraform {
 }
 
 locals {
-  full_account_id   = format("%s-sa-%s", var.name, var.name_suffix)
-  full_display_name = format("%s ServiceAccount-%s", var.display_name, var.name_suffix)
+  full_account_id   = format("%s-%s", var.name, var.name_suffix)
+  full_display_name = format("%s %s", var.display_name, var.name_suffix)
   roles             = toset(var.roles)
   sensitive_roles   = ["roles/owner" /* we want to prevent terraform from granting sensitive roles to any resources */]
   filtered_roles    = setsubtract(local.roles, local.sensitive_roles)


### PR DESCRIPTION
... will help to gain more character space in the SA names

This change is easily backward-compatible:
- either suffix `var.name` with `"-sa"`
- or prefix `var.name_suffix` with `"sa-"`